### PR TITLE
Don't crash when path to executable contains unicode

### DIFF
--- a/vnet
+++ b/vnet
@@ -293,7 +293,7 @@ def main():
         logger.info("Shutting down nodes...")
         for (name, node) in topo.nodes.items():
             node.lookup(conn)
-            logger.debug("stopping node %s %s" % (name, str(node.vm_instance)))
+            logger.debug("stopping node %s %s" % (name, node.vm_instance))
             node.stop()
             node.undefine(conn)
     


### PR DESCRIPTION
fixes this error when shutting down the test:

```
vnet           : Shutting down nodes...
Traceback (most recent call last):
  File "./vnet", line 437, in <module>
    main()
  File "./vnet", line 296, in main
    logger.debug("stopping node %s %s" % (name, str(node.vm_instance)))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xb5' in position 15: ordinal not in range(128)
```

str() doesn't appear to be needed here
