### PR TITLE
make libvirt optional

### DIFF
--- a/desvirt/vm.py
+++ b/desvirt/vm.py
@@ -16,7 +16,10 @@ from .vnet import VirtualNet
 from .riotnative import RIOT
 from string import Template
 
-import libvirt
+try:
+    import libvirt
+except:
+    print "libvirt not found, you won't be able to work with qemu"
 import hashlib
 
 all_domains = None

--- a/vnet
+++ b/vnet
@@ -10,7 +10,10 @@ import atexit
 import shlex
 import logging
 
-import libvirt
+try:
+    import libvirt
+except:
+    print "libvirt not found, you won't be able to work with qemu"
 import pickle
 from optparse import OptionParser
 


### PR DESCRIPTION
It isn't needed for riot-native.
