### PR TITLE
allow to specify the TCP port in XML

### DIFF
--- a/desvirt/riotnative.py
+++ b/desvirt/riotnative.py
@@ -27,9 +27,10 @@ def get_free_tcp_port(start_port=4711,logger=None):
 
 class RIOT():
 
-    def __init__(self, fullname, binary, session_name, tap):
+    def __init__(self, fullname, binary, tcp_port, session_name, tap):
         self.fullname = fullname
         self.binary = binary
+        self.tcp_port = tcp_port
         self.session_name = session_name
         self.tap = tap
         self.pid = None
@@ -37,7 +38,10 @@ class RIOT():
         self.logger = logging.getLogger("")
 
     def create(self):
-        port_number = get_free_tcp_port(logger=self.logger)
+        if self.tcp_port:
+            port_number = int(self.tcp_port)
+        else:
+            port_number = get_free_tcp_port(logger=self.logger)
         start_riot = "%s %s -t %d -d" % (self.binary, self.tap, port_number)
         self.logger.info("Start the RIOT: %s" % start_riot)
         try:

--- a/desvirt/vm.py
+++ b/desvirt/vm.py
@@ -32,10 +32,11 @@ class VMException(Exception):
             s.message = msg
 
 class VM():
-    def __init__(self, name, nodeType, nics=None, binary=None, vmgroup_name=""):
+    def __init__(self, name, nodeType, nics=None, binary=None, tcp_port=None, vmgroup_name=""):
         self.name = name
         self.nodeType = nodeType
         self.binary = binary
+        self.tcp_port = tcp_port
         self.nics = nics
         if not nics:
             self.nics = []
@@ -71,7 +72,7 @@ class VM():
                 return False
         elif self.nodeType == "riot_native":
             logging.getLogger("Looking up this node")
-            self.vm_instance = RIOT(self.fullname, self.binary, self.vmgroup_name, self.nics[0].tap)
+            self.vm_instance = RIOT(self.fullname, self.binary, self.tcp_port, self.vmgroup_name, self.nics[0].tap)
             return True
 
     def define(self, conn=None):
@@ -84,7 +85,7 @@ class VM():
             if not self.binary:
                 logging.getLogger("").error("No binary for RIOT native given. Exiting...")
                 sys.exit(1)
-            self.vm_instance = RIOT(self.fullname, self.binary, self.vmgroup_name, self.nics[0].tap)
+            self.vm_instance = RIOT(self.fullname, self.binary, self.tcp_port, self.vmgroup_name, self.nics[0].tap)
 
     def undefine(self, conn=None):
         # TODO: needs here anything to be done for RIOT native?

--- a/desvirt/xmltopology.py
+++ b/desvirt/xmltopology.py
@@ -77,12 +77,13 @@ class XMLTopology():
             name = node.getAttribute('name')
             nodeType = node.getAttribute('type')
             binary = node.getAttribute('binary')
+            tcp_port = node.getAttribute('tcp_port')
             logging.getLogger("").debug("Found node %s of type %s" % (name, nodeType))
             default_ifaces = self.nodetypes[nodeType]
             interfaces = []
             interfaces.extend(default_ifaces)
-            logging.getLogger("").debug("Binary for %s is %s" % (name, binary))
-            n = self.nodeHandler(name, nodeType, binary)
+            logging.getLogger("").debug("Binary for %s is %s, TCP port is %s" % (name, binary, tcp_port))
+            n = self.nodeHandler(name, nodeType, binary, tcp_port)
             nodes.append(n)
 
             for interface in interfaces:

--- a/vnet
+++ b/vnet
@@ -96,7 +96,7 @@ def nicHandler(name, net=None, node=None, mac=None):
 
     return nic
 
-def nodeHandler(name, nodeType, elf_file=None):
+def nodeHandler(name, nodeType, elf_file=None, tcp_port=None):
     global topo
     global taps
     global management_net
@@ -112,7 +112,7 @@ def nodeHandler(name, nodeType, elf_file=None):
     if not name in macs:
         macs[name] = {}
 
-    node = vm.VM(name, nodeType, binary=elf_file, vmgroup_name=topo.name)
+    node = vm.VM(name, nodeType, binary=elf_file, tcp_port=tcp_port, vmgroup_name=topo.name)
 
     if nodeType == "meshrouter":
         need_libvirt = True


### PR DESCRIPTION
This patch allows to set the TCP port for RIOT native in the XML file in
order to ease script development.
