### PR TITLE
Allow bandwidth definition for links inside xml

### DIFF
--- a/desvirt/xmltopology.py
+++ b/desvirt/xmltopology.py
@@ -101,6 +101,8 @@ class XMLTopology():
             
             loss = link.getAttribute('loss')
 
+            rate = link.getAttribute('rate')
+
             delay = link.getAttribute('delay')
             if not delay:
                 delay = 0
@@ -116,7 +118,7 @@ class XMLTopology():
                 if uni_directional_str=="true":
                     uni_directional = True
 
-            self.linkHandler(from_node, from_if, to_node, to_if, None, None, loss, delay, uni_directional)
+            self.linkHandler(from_node, from_if, to_node, to_if, None, rate, loss, delay, uni_directional)
 
 #            print("link from_node: %s, to_node: %s type: %s" %(from_node, to_node, linkType))
 #            print(rates)

--- a/vnet
+++ b/vnet
@@ -141,9 +141,11 @@ def linkHandler(from_node, from_if, to_node, to_if, channel, rate, loss, delay, 
     if to_tap.net.name == from_tap.net.name:
         net = to_tap.net
         loss_percent = float(loss) * 100
-        net.add_link(from_tap.tap, to_tap.tap, packet_loss=loss_percent, delay=float(delay))
+        if not rate:
+            rate = '100mbit'
+        net.add_link(from_tap.tap, to_tap.tap, bandwidth=rate, packet_loss=loss_percent, delay=float(delay))
         if not uni_directional:
-            net.add_link(to_tap.tap, from_tap.tap, packet_loss=loss_percent, delay=float(delay))
+            net.add_link(to_tap.tap, from_tap.tap, bandwidth=rate, packet_loss=loss_percent, delay=float(delay))
 
 def usage():
     print("Usage: start_vnet <topology.xml>")


### PR DESCRIPTION
The change enables rate definition for links inside the topology's xml based on tc-htb's rate setting. If the rate attribute is omitted, the default value of 100mbit is used (the setting that prior to this PR was used).

Example:
```xml
<link broadcast_loss="0.0" from_if="cc2420" from_node="a1" rate="500kbit" loss="0.3" to_if="cc2420" to_node="b3" uni="false"/>
```