### PR TITLE
Store list for all ports

### DIFF
--- a/desvirt/riotnative.py
+++ b/desvirt/riotnative.py
@@ -55,8 +55,10 @@ class RIOT():
             self.logger.info("PID: %d" % self.pid)
 
             with open(self.routers_file, "a") as f:
-                print("port=" + str(port_number))
-                print(str(port_number), file=f)
+                position = self.tap.split("_", 1)[1] #a1..e7
+                x = ord(position[0]) - ord('a') #0..4
+                y = int(position[1]) - 1 #0..4
+                print(str(x) + "," + str(y) + "," + str(port_number), file=f)
 
         except subprocess.CalledProcessError:
             self.logger.error("creating RIOT native process failed")

--- a/desvirt/riotnative.py
+++ b/desvirt/riotnative.py
@@ -1,8 +1,11 @@
+from __future__ import print_function
+
 import logging
 import subprocess
 import sys
 import socket
 import re
+import os
 
 reserved_ports = []
 
@@ -36,6 +39,7 @@ class RIOT():
         self.pid = None
 
         self.logger = logging.getLogger("")
+        self.routers_file = "./ports.list"
 
     def create(self):
         if self.tcp_port:
@@ -49,6 +53,11 @@ class RIOT():
             proc = subprocess.Popen(start_riot, shell=True)
             self.pid = proc.pid
             self.logger.info("PID: %d" % self.pid)
+
+            with open(self.routers_file, "a") as f:
+                print("port=" + str(port_number))
+                print(str(port_number), file=f)
+
         except subprocess.CalledProcessError:
             self.logger.error("creating RIOT native process failed")
             sys.exit(1)

--- a/desvirt/riotnative.py
+++ b/desvirt/riotnative.py
@@ -57,8 +57,11 @@ class RIOT():
             with open(self.routers_file, "a") as f:
                 position = self.tap.split("_", 1)[1] #a1..e7
                 x = ord(position[0]) - ord('a') + 1 #1..5
-                y = int(position[1]) #1..5
-                print(str(x) + "," + str(y) + "," + str(port_number), file=f)
+                if (len(position) > 1):
+                    y = int(position[1]) #1..5
+                    print(str(x) + "," + str(y) + "," + str(port_number), file=f)
+                else:
+                    print(str(x) + "," + str(port_number), file=f)
 
         except subprocess.CalledProcessError:
             self.logger.error("creating RIOT native process failed")

--- a/desvirt/riotnative.py
+++ b/desvirt/riotnative.py
@@ -56,8 +56,8 @@ class RIOT():
 
             with open(self.routers_file, "a") as f:
                 position = self.tap.split("_", 1)[1] #a1..e7
-                x = ord(position[0]) - ord('a') #0..4
-                y = int(position[1]) - 1 #0..4
+                x = ord(position[0]) - ord('a') + 1 #1..5
+                y = int(position[1]) #1..5
                 print(str(x) + "," + str(y) + "," + str(port_number), file=f)
 
         except subprocess.CalledProcessError:

--- a/vnet
+++ b/vnet
@@ -284,6 +284,8 @@ def main():
             register_hostnames(topo.name, topo.nodes)
 
     if options.start:
+        os.remove("./ports.list")
+        logger.debug("removed ports.lock")
         create_lockfile(lockfile, content="running")
         if need_libvirt:
             myconn = libvirt.open('qemu:///system')

--- a/vnet
+++ b/vnet
@@ -284,8 +284,12 @@ def main():
             register_hostnames(topo.name, topo.nodes)
 
     if options.start:
-        os.remove("./ports.list")
-        logger.debug("removed ports.lock")
+        try:
+            os.remove("./ports.list")
+            logger.debug("removed ports.lock")
+        except:
+            open("./ports.list", "w").close()
+
         create_lockfile(lockfile, content="running")
         if need_libvirt:
             myconn = libvirt.open('qemu:///system')


### PR DESCRIPTION
This PR adds a nifty feature originally implemented by @mehlis – it stores a file `ports.list` containing the coordinates and corresponding ports of all RIOTs in the currently (or last) running network. I've found it to be pretty useful during automated tests/experiments, and I've extended it to work with line topologies (and not cause errors when there's no initial `ports.list` file yet).
In case you agree that this is useful and should be merged, I'd squash it into two commits, one for @mehlis ' initial authorship and one for my fixes.