### PR TITLE
Kill **all** the RIOT, not only the first one.

### DIFF
--- a/desvirt/riotnative.py
+++ b/desvirt/riotnative.py
@@ -72,7 +72,8 @@ class RIOT():
     def destroy(self):
         self.logger.info("Kill the RIOT: %s (%s)" % (self.binary, self.pid))
         kill_string = ['pkill -f -9 "%s %s"' % (self.binary, self.tap)]
-        if subprocess.call(kill_string, stderr=subprocess.PIPE, shell=True):
+        process = subprocess.call(kill_string, stderr=subprocess.PIPE, shell=True)
+        if process != -9:
             self.logger.error("killing RIOT native process failed")
         self.is_active = False
 

--- a/desvirt/riotnative.py
+++ b/desvirt/riotnative.py
@@ -74,7 +74,6 @@ class RIOT():
         kill_string = ['pkill -f -9 "%s %s"' % (self.binary, self.tap)]
         if subprocess.call(kill_string, stderr=subprocess.PIPE, shell=True):
             self.logger.error("killing RIOT native process failed")
-            sys.exit(1)
         self.is_active = False
 
     def isActive(self):


### PR DESCRIPTION
dont end process after **first** destroy(), the other `socat` instances must be destroyed too.
